### PR TITLE
docs: align Order Tracking identity and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Order Tracking Service
+# Order Tracking
 
-Order Tracking Service is a **Spring Boot 3** backend that accepts batches of tracking updates over HTTP, publishes one Kafka record per event keyed by `orderId`, and consumes those records to apply domain transition rules, append accepted events to an audit history, and update a read-oriented projection. Kafka separates request acceptance from downstream persistence; the ordering guarantee is per order within its Kafka partition, not global.
+Order Tracking is a **Spring Boot 3** backend that accepts batches of tracking updates over HTTP, publishes one Kafka record per event keyed by `orderId`, and consumes those records to apply domain transition rules, append accepted events to an audit history, and update a read-oriented projection. Kafka separates request acceptance from downstream persistence; the ordering guarantee is per order within its Kafka partition, not global.
 
 ### Current limitations
 
@@ -8,6 +8,12 @@ Order Tracking Service is a **Spring Boot 3** backend that accepts batches of tr
 - Redelivery can therefore re-attempt database work after a partial failure, and there is no dedicated safe replay/backfill path yet.
 - The repository documents local startup with Kafka and Postgres, but the complete clean-checkout path still needs explicit verification from a fresh clone.
 - Actuator and Prometheus endpoints exist, but there is no published performance baseline, SLO, consumer-lag dashboard, or operational runbook.
+
+## Project links
+
+- [Portfolio case study](https://enriquegoberna.com/projects/order-tracking/)
+- [Scaling Order Tracking with Kafka, Domain Events, and Auto-Ingestion](https://enriquegoberna.com/posts/scaling-order-tracking-with-kafka-domain-events-and-auto-ingestion/)
+- [Engineering portfolio](https://enriquegoberna.com/)
 
 ---
 


### PR DESCRIPTION
## Summary

Aligns the repository-facing Order Tracking identity with the current portfolio without turning the README into recruiter copy.

## Changes

- Uses `Order Tracking` as the public project name.
- Adds reciprocal links to the portfolio case study, main engineering article, and portfolio home.
- Preserves the existing factual README introduction, per-order ordering boundary, delivery limitations, and preproduction wording.

## Verification

- Exact diff reviewed: one README, 9 additions / 3 deletions.
- Confirmed no production, exactly-once, replay-safety, throughput, or reliability claim was strengthened.
- Confirmed the current limitations and AWS preproduction qualification remain intact.
- Verified the main public article URL; the case-study route matches the portfolio project front matter.
- No build/test execution is required for this documentation-only change; no runtime or infrastructure bytes changed.

## Known risks / limitations

- The live GitHub repository description is separate repository metadata and still contains `portfolio project`, `showcase`, and `production-ready` wording. Updating that metadata remains an external action for portfolio-roadmap#17.
- LinkedIn and GitHub profile pins are outside this repository PR.

Related to egobb/portfolio-roadmap#17